### PR TITLE
Add limitSpec support for groupBy queries

### DIFF
--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -170,7 +170,25 @@ module Druid
       @properties.to_json
     end
 
+   def limit_spec(limit, columns)
+      @properties[:limitSpec] = {
+        :type => :default,
+        :limit => limit,
+        :columns => order_by_column_spec(columns)
+      }
+      self
+    end 
+
     private
+
+    def order_by_column_spec(columns)
+      columns.map do |dimension, direction|
+        {
+          :dimension => dimension,
+          :direction => direction
+        }
+      end
+    end
 
     def mk_interval(from, to)
       from = today + from if from.is_a?(Fixnum)

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -418,4 +418,16 @@ end
     }
   end
 
+  it 'takes type, limit and columns from limit method' do
+    @query.limit_spec(10, :a => 'ASCENDING', :b => 'DESCENDING')
+    result = JSON.parse(@query.to_json)
+    result['limitSpec'].should == {
+      'type' => 'default',
+      'limit' => 10,
+      'columns' => [
+        { 'dimension' => 'a', 'direction' => 'ASCENDING'},
+        { 'dimension' => 'b', 'direction' => 'DESCENDING'}
+      ]
+    }
+  end
 end


### PR DESCRIPTION
It would be nice to have limitSpec support for groupBy queries.
Detailed information about limitSpec could be found [there](http://druid.io/docs/latest/LimitSpec.html).
